### PR TITLE
Remove icon assets from Robopack Rocket

### DIFF
--- a/robopack-rocket/README.md
+++ b/robopack-rocket/README.md
@@ -1,0 +1,47 @@
+# Robopack Rocket
+
+Robopack Rocket is a Firefox Manifest V3 extension that upgrades the custom PowerShell settings editor on [robopack.com](https://robopack.com) with a fully featured coding experience. It transparently keeps the original `<textarea>` as the source of truth so site forms continue to work while you enjoy syntax highlighting, code-editor ergonomics, and persistent sizing.
+
+## Features
+
+- **Monaco + Prism highlighting** – Loads the Monaco editor from a CDN when allowed. If RoboPack’s CSP blocks it, the extension automatically falls back to a Prism.js powered editor and shows a gentle toast explaining the fallback.
+- **Two-way syncing** – The original `<textarea>` stays in place (hidden when the editor is active) and stays in sync with every keystroke so native site behaviour keeps working.
+- **Resizable workspace** – Drag the corner grip or use the keyboard to adjust editor height. The chosen size is remembered per RoboPack path.
+- **Toggle friendly** – Switch between the stock textarea and the enhanced editor at any time without losing content.
+- **Options page** – Customise selectors, fonts, tab stops, wrapping, theme override, and your preferred highlighter (Monaco, Prism, or automatic).
+- **Per-site persistence** – Editor dimensions and preferences are stored per origin + path so different RoboPack sections can have different layouts.
+- **Accessible toasts & controls** – Keyboard focus, labelled buttons, and polite toasts keep the experience inclusive.
+
+## Installation
+
+1. Clone or download this repository.
+2. Open Firefox and visit `about:debugging#/runtime/this-firefox`.
+3. Click **Load Temporary Add-on…** and choose the `manifest.json` file inside the `robopack-rocket` directory.
+4. Open a RoboPack page containing a large PowerShell textarea (e.g. custom settings). The extension enhances it automatically.
+
+## Usage
+
+- Click **Enhance PS Editor** to switch to the Monaco/Prism editor. Click again to revert to the stock textarea.
+- Drag the resize grip at the bottom of the editor or use <kbd>Arrow Up/Down</kbd> (with <kbd>Shift</kbd> for larger steps) while the grip is focused to change height.
+- Open the Options page from the Add-ons Manager or the extension’s context menu to tweak selectors and editor behaviour. Use **Test selectors on current tab** to flash outlines around matching textareas.
+
+## Privacy
+
+All processing happens locally in your browser. No code, telemetry, or personal data leaves the page.
+
+## Troubleshooting
+
+- **Monaco fails to load** – RoboPack’s Content Security Policy might block the CDN. The extension will fall back to Prism automatically and show a toast describing the reason. You can force Prism as the preferred highlighter from Options.
+- **Textarea not detected** – Adjust the selector list in Options or use the built-in heuristic (clear the selector field).
+- **Styling conflicts** – The editor inherits container width and sits inside the existing form markup, so layout changes should be minimal. If custom CSS on the site interferes, try reducing the editor height or toggling back to the native textarea.
+
+## Monaco vs. Prism
+
+| Feature | Monaco | Prism |
+| --- | --- | --- |
+| Syntax highlighting | Full language server level | Token-based highlight |
+| Editing experience | Rich IDE-like (multi-cursor, IntelliSense-ready) | Lightweight, contenteditable overlay |
+| CSP friendliness | May be blocked by strict CSP | Works almost everywhere |
+| Bundle size | Larger (lazy loaded) | Minimal |
+
+Choose **Auto** to enjoy Monaco whenever possible with transparent fallback to Prism.

--- a/robopack-rocket/content/content.js
+++ b/robopack-rocket/content/content.js
@@ -1,0 +1,415 @@
+(() => {
+  const browserAPI = window.browser ?? window.chrome;
+  if (!browserAPI?.storage) {
+    return;
+  }
+
+  const DEFAULT_SETTINGS = {
+    selectors: '',
+    preferredHighlighter: 'auto',
+    fontSize: 14,
+    tabSize: 4,
+    wordWrap: false,
+    theme: 'auto'
+  };
+
+  const SETTINGS_KEY = 'robopackRocketSettings';
+  const SIZE_PREFIX = 'robopackRocketSize:';
+  let toastPromise = null;
+
+  const ready = document.readyState === 'complete' || document.readyState === 'interactive'
+    ? Promise.resolve()
+    : new Promise((resolve) => document.addEventListener('DOMContentLoaded', resolve, { once: true }));
+
+  ready.then(async () => {
+    const settings = await loadSettings();
+    ensureToastInjected();
+    const textarea = findTargetTextarea(settings);
+    if (!textarea) {
+      return;
+    }
+
+    enhanceTextarea(textarea, settings);
+  });
+
+  browserAPI.runtime.onMessage.addListener((message, sender) => {
+    if (message?.type === 'robopack-rocket-test-selectors') {
+      const settings = message.settings;
+      const matches = collectCandidateTextareas(settings);
+      matches.forEach((ta) => {
+        ta.classList.add('rpwsh-testing-outline');
+        ta.style.outline = '2px dashed #38bdf8';
+        setTimeout(() => {
+          ta.style.outline = '';
+          ta.classList.remove('rpwsh-testing-outline');
+        }, 1500);
+      });
+      return Promise.resolve({ count: matches.length });
+    }
+    return undefined;
+  });
+
+  async function loadSettings() {
+    const stored = await browserAPI.storage.local.get(SETTINGS_KEY);
+    return Object.assign({}, DEFAULT_SETTINGS, stored?.[SETTINGS_KEY] ?? {});
+  }
+
+  function parseSelectors(selectorString) {
+    return selectorString
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  function collectCandidateTextareas(settings) {
+    const selectors = parseSelectors(settings.selectors);
+    const candidates = new Set();
+    selectors.forEach((sel) => {
+      try {
+        document.querySelectorAll(sel).forEach((node) => {
+          if (node instanceof HTMLTextAreaElement) {
+            candidates.add(node);
+          }
+        });
+      } catch (err) {
+        console.warn('[Robopack Rocket] Invalid selector', sel, err);
+      }
+    });
+
+    if (!selectors.length) {
+      const heuristicSelectors = [
+        'textarea[spellcheck="false"]',
+        'textarea[id*="script" i]',
+        'textarea[name*="script" i]',
+        'textarea[class*="code" i]'
+      ];
+      heuristicSelectors.forEach((sel) => {
+        document.querySelectorAll(sel).forEach((node) => {
+          if (node instanceof HTMLTextAreaElement) {
+            candidates.add(node);
+          }
+        });
+      });
+    }
+
+    return Array.from(candidates);
+  }
+
+  function pickBestTextarea(textareas) {
+    let best = null;
+    let bestScore = -Infinity;
+    textareas.forEach((ta) => {
+      const rows = Number(ta.rows || 0) || 10;
+      const cols = Number(ta.cols || 0) || 80;
+      const rect = ta.getBoundingClientRect();
+      const areaScore = Math.max(rect.width * rect.height, rows * cols * 10);
+      const lengthScore = (ta.value?.length ?? 0) / 10;
+      const score = areaScore + lengthScore;
+      if (score > bestScore) {
+        bestScore = score;
+        best = ta;
+      }
+    });
+    return best;
+  }
+
+  function findTargetTextarea(settings) {
+    const candidates = collectCandidateTextareas(settings);
+    if (!candidates.length) {
+      return null;
+    }
+    return pickBestTextarea(candidates);
+  }
+
+  function detectTheme(preference) {
+    if (preference && preference !== 'auto') {
+      return preference;
+    }
+
+    const isDarkViaMedia = window.matchMedia?.('(prefers-color-scheme: dark)')?.matches;
+    if (isDarkViaMedia) {
+      return 'dark';
+    }
+
+    const body = document.body;
+    if (body) {
+      const style = window.getComputedStyle(body);
+      const bg = style.backgroundColor || '#ffffff';
+      if (isDarkColor(bg)) {
+        return 'dark';
+      }
+    }
+    return 'light';
+  }
+
+  function isDarkColor(color) {
+    const ctx = document.createElement('canvas').getContext('2d');
+    if (!ctx) {
+      return false;
+    }
+    ctx.fillStyle = color;
+    const rgba = ctx.fillStyle;
+    const match = rgba.match(/rgba?\(([^)]+)\)/i);
+    if (!match) {
+      return false;
+    }
+    const [r, g, b] = match[1].split(',').map((v) => parseFloat(v));
+    const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+    return luminance < 0.5;
+  }
+
+  function ensureToastInjected() {
+    if (window.RoboToast) {
+      return Promise.resolve();
+    }
+    if (toastPromise) {
+      return toastPromise;
+    }
+    toastPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = browserAPI.runtime.getURL('lib/toast.js');
+      script.type = 'text/javascript';
+      script.addEventListener('load', () => resolve(), { once: true });
+      script.addEventListener('error', (error) => reject(error), { once: true });
+      document.documentElement.appendChild(script);
+    }).catch((error) => {
+      console.warn('Failed to load Robopack Rocket toast helper', error);
+    });
+    return toastPromise;
+  }
+
+  function enhanceTextarea(textarea, settings) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'rpwsh-wrapper';
+    textarea.parentNode?.insertBefore(wrapper, textarea);
+    wrapper.appendChild(textarea);
+
+    const toolbar = document.createElement('div');
+    toolbar.className = 'rpwsh-toolbar';
+    const toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'rpwsh-toggle';
+    toggleBtn.textContent = 'Enhance PS Editor';
+    toggleBtn.setAttribute('aria-pressed', 'false');
+    toggleBtn.setAttribute('aria-label', 'Toggle Robopack Rocket editor');
+    toolbar.appendChild(toggleBtn);
+    wrapper.insertBefore(toolbar, textarea);
+
+    const host = document.createElement('div');
+    host.className = 'rpwsh-editor-host rpwsh-hidden';
+    const surface = document.createElement('div');
+    surface.className = 'rpwsh-editor-surface';
+    host.appendChild(surface);
+
+    const resizer = document.createElement('div');
+    resizer.className = 'rpwsh-resize-handle';
+    resizer.setAttribute('role', 'separator');
+    resizer.setAttribute('aria-orientation', 'vertical');
+    resizer.tabIndex = 0;
+    const grip = document.createElement('div');
+    grip.className = 'rpwsh-resize-grip';
+    resizer.appendChild(grip);
+    host.appendChild(resizer);
+    wrapper.appendChild(host);
+
+    const resizeState = {
+      active: false,
+      startY: 0,
+      startHeight: 0
+    };
+
+    const sizeKey = buildSizeKey(textarea);
+
+    applyStoredSize(host, sizeKey);
+
+    let pendingSizeSave = null;
+    const resizeObserver = new ResizeObserver(() => {
+      if (pendingSizeSave) {
+        cancelAnimationFrame(pendingSizeSave);
+      }
+      pendingSizeSave = requestAnimationFrame(() => {
+        saveSize(host, sizeKey);
+        pendingSizeSave = null;
+      });
+    });
+    resizeObserver.observe(host);
+
+    const onPointerMove = (event) => {
+      if (!resizeState.active) return;
+      const delta = event.clientY - resizeState.startY;
+      const newHeight = Math.max(200, resizeState.startHeight + delta);
+      host.style.height = `${newHeight}px`;
+    };
+
+    const stopResize = () => {
+      if (!resizeState.active) return;
+      resizeState.active = false;
+      window.removeEventListener('pointermove', onPointerMove);
+      window.removeEventListener('pointerup', stopResize);
+      window.removeEventListener('pointercancel', stopResize);
+      saveSize(host, sizeKey);
+    };
+
+    resizer.addEventListener('pointerdown', (event) => {
+      resizeState.active = true;
+      resizeState.startY = event.clientY;
+      resizeState.startHeight = host.getBoundingClientRect().height;
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', stopResize);
+      window.addEventListener('pointercancel', stopResize);
+      event.preventDefault();
+    });
+
+    resizer.addEventListener('keydown', (event) => {
+      const step = event.shiftKey ? 40 : 10;
+      if (event.key === 'ArrowUp') {
+        adjustHeight(-step);
+        event.preventDefault();
+      } else if (event.key === 'ArrowDown') {
+        adjustHeight(step);
+        event.preventDefault();
+      }
+    });
+
+    function adjustHeight(delta) {
+      const rect = host.getBoundingClientRect();
+      const next = Math.max(200, rect.height + delta);
+      host.style.height = `${next}px`;
+      saveSize(host, sizeKey);
+    }
+
+    let editorModulePromise = null;
+    let editorInstance = null;
+    let editorApi = null;
+    let disconnectTextareaListener = null;
+    let suppressSync = false;
+
+    async function enableEditor() {
+      if (editorInstance) {
+        return;
+      }
+      textarea.classList.add('rpwsh-hidden');
+      host.classList.remove('rpwsh-hidden');
+      toggleBtn.setAttribute('aria-pressed', 'true');
+      toggleBtn.textContent = 'Revert to Original';
+
+      const theme = detectTheme(settings.theme);
+      host.dataset.theme = theme;
+
+      editorModulePromise = editorModulePromise || import(browserAPI.runtime.getURL('content/editor.js'));
+      try {
+        const module = await editorModulePromise;
+        editorInstance = await module.initEditor(textarea, {
+          hostElement: surface,
+          settings,
+          theme
+        });
+        editorApi = editorInstance.api;
+        editorApi.setTheme(theme);
+        editorApi.setValue(textarea.value);
+        disconnectTextareaListener = attachTextareaSync();
+        window.RoboToast?.show(`Robopack Rocket active (${editorInstance.mode === 'monaco' ? 'Monaco' : 'Prism'})`, {
+          theme,
+          duration: 3000
+        });
+        if (editorInstance.fallbackReason) {
+          const reason = String(editorInstance.fallbackReason).slice(0, 160);
+          window.RoboToast?.show(`Monaco editor unavailable: ${reason}`, {
+            theme,
+            duration: 5000
+          });
+        }
+      } catch (error) {
+        console.error('Failed to initialise Robopack Rocket', error);
+        window.RoboToast?.show('Unable to load enhanced editor. See console for details.', {
+          duration: 5000
+        });
+        disableEditor();
+      }
+    }
+
+    function attachTextareaSync() {
+      if (!editorApi) return null;
+      const onEditorChange = editorApi.onChange((value) => {
+        if (suppressSync) return;
+        suppressSync = true;
+        if (textarea.value !== value) {
+          textarea.value = value;
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+          textarea.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+        suppressSync = false;
+      });
+      const onTextareaInput = (event) => {
+        if (suppressSync) return;
+        suppressSync = true;
+        const newValue = textarea.value;
+        if (editorApi.getValue() !== newValue) {
+          editorApi.setValue(newValue);
+        }
+        suppressSync = false;
+      };
+      textarea.addEventListener('input', onTextareaInput);
+      textarea.addEventListener('change', onTextareaInput);
+      return () => {
+        onEditorChange?.();
+        textarea.removeEventListener('input', onTextareaInput);
+        textarea.removeEventListener('change', onTextareaInput);
+      };
+    }
+
+    async function disableEditor() {
+      toggleBtn.setAttribute('aria-pressed', 'false');
+      toggleBtn.textContent = 'Enhance PS Editor';
+      textarea.classList.remove('rpwsh-hidden');
+      host.classList.add('rpwsh-hidden');
+      host.dataset.theme = '';
+      disconnectTextareaListener?.();
+      disconnectTextareaListener = null;
+      if (editorInstance?.dispose) {
+        editorInstance.dispose();
+      }
+      editorInstance = null;
+      editorApi = null;
+    }
+
+    toggleBtn.addEventListener('click', () => {
+      if (editorInstance) {
+        disableEditor();
+      } else {
+        enableEditor();
+      }
+    });
+
+    toggleBtn.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        toggleBtn.click();
+      }
+    });
+
+    enableEditor();
+  }
+
+  function buildSizeKey(textarea) {
+    const identifier = textarea.id || textarea.name || textarea.getAttribute('data-testid') || 'default';
+    return `${SIZE_PREFIX}${location.origin}${location.pathname}::${identifier}`;
+  }
+
+  async function applyStoredSize(host, key) {
+    const stored = await browserAPI.storage.local.get(key);
+    const size = stored?.[key];
+    if (size?.height) {
+      host.style.height = `${size.height}px`;
+    }
+    if (size?.width) {
+      host.style.width = `${size.width}px`;
+    }
+  }
+
+  function saveSize(host, key) {
+    const rect = host.getBoundingClientRect();
+    const payload = { [key]: { width: rect.width, height: rect.height } };
+    browserAPI.storage.local.set(payload).catch((err) => console.warn('Failed to persist size', err));
+  }
+})();

--- a/robopack-rocket/content/editor.css
+++ b/robopack-rocket/content/editor.css
@@ -1,0 +1,181 @@
+:root {
+  --rpwsh-editor-border: 1px solid rgba(0, 0, 0, 0.15);
+  --rpwsh-editor-radius: 6px;
+  --rpwsh-editor-bg: rgba(20, 24, 28, 0.9);
+  --rpwsh-editor-font-size: 14px;
+  --rpwsh-editor-spacing: 0.5rem;
+}
+
+.rpwsh-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 0.25rem;
+  font: inherit;
+}
+
+.rpwsh-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+.rpwsh-toggle {
+  background: linear-gradient(135deg, #1f6feb, #1755c2);
+  border: none;
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.rpwsh-toggle:focus-visible {
+  outline: 2px solid #fcd34d;
+  outline-offset: 2px;
+}
+
+.rpwsh-toggle:hover {
+  box-shadow: 0 6px 12px rgba(23, 85, 194, 0.35);
+  transform: translateY(-1px);
+}
+
+.rpwsh-toggle[aria-pressed="true"] {
+  background: linear-gradient(135deg, #64748b, #475569);
+}
+
+.rpwsh-editor-host {
+  position: relative;
+  width: 100%;
+  min-height: 280px;
+  border: var(--rpwsh-editor-border);
+  border-radius: var(--rpwsh-editor-radius);
+  overflow: hidden;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.rpwsh-editor-host[data-theme="light"] {
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+.rpwsh-resize-handle {
+  position: absolute;
+  inset-inline-end: 0;
+  inset-block-end: 0;
+  width: 100%;
+  block-size: 12px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.25), rgba(30, 41, 59, 0.45));
+  cursor: ns-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+}
+
+.rpwsh-resize-grip {
+  width: 40px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.rpwsh-editor-surface,
+.rpwsh-editor-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.rpwsh-hidden {
+  display: none !important;
+}
+
+.rpwsh-toast {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2147483647;
+  background: rgba(17, 24, 39, 0.92);
+  color: #e2e8f0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.45);
+  max-width: 320px;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+
+.rpwsh-toast[data-theme="light"] {
+  background: rgba(248, 250, 252, 0.95);
+  color: #0f172a;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.2);
+}
+
+.rpwsh-toast button {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  margin-inline-start: 0.5rem;
+}
+
+.rpwsh-prism-container {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  font-family: "Fira Code", "Cascadia Code", "Consolas", "Monaco", monospace;
+  font-size: var(--rpwsh-editor-font-size);
+  background: inherit;
+  color: inherit;
+}
+
+.rpwsh-prism-editable {
+  outline: none;
+  min-height: 100%;
+  caret-color: currentColor;
+  white-space: pre;
+}
+
+.rpwsh-prism-pre {
+  margin: 0;
+  padding: 1rem;
+  min-height: 100%;
+}
+
+.rpwsh-resize-handle:focus-visible {
+  outline: 2px solid #facc15;
+  outline-offset: -2px;
+}
+.rpwsh-prism-container {
+  position: relative;
+}
+
+.rpwsh-prism-highlight {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.rpwsh-prism-editable {
+  position: absolute;
+  inset: 0;
+  padding: 1rem;
+  color: transparent;
+  background: transparent;
+  overflow: auto;
+  white-space: pre;
+}
+
+.rpwsh-prism-editable::selection {
+  background: rgba(125, 211, 252, 0.35);
+}

--- a/robopack-rocket/content/editor.js
+++ b/robopack-rocket/content/editor.js
@@ -1,0 +1,41 @@
+const browserAPI = window.browser ?? window.chrome;
+const DEFAULT_OPTIONS = {
+  fontSize: 14,
+  tabSize: 4,
+  wordWrap: false
+};
+
+export async function initEditor(textarea, options = {}) {
+  const hostElement = options.hostElement;
+  if (!hostElement) {
+    throw new Error('hostElement is required to initialise the editor');
+  }
+  const settings = Object.assign({}, DEFAULT_OPTIONS, options.settings ?? {});
+  const theme = options.theme ?? 'light';
+  const preferred = (settings.preferredHighlighter || options.preferredHighlighter || 'auto').toLowerCase();
+
+  let lastError = null;
+  if (preferred !== 'prism') {
+    try {
+      const monacoModule = await import(browserAPI.runtime.getURL('content/monaco-loader.js'));
+      const adapter = await monacoModule.createMonacoAdapter(textarea, {
+        hostElement,
+        options: settings,
+        theme
+      });
+      return Object.assign(adapter, { mode: 'monaco', fallbackReason: null });
+    } catch (error) {
+      console.warn('[Robopack Rocket] Monaco unavailable, falling back to Prism', error);
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const prismModule = await import(browserAPI.runtime.getURL('content/prism-loader.js'));
+  const adapter = await prismModule.createPrismAdapter(textarea, {
+    hostElement,
+    options: settings,
+    theme,
+    fallbackReason: lastError || (preferred === 'prism' ? null : 'Monaco disabled')
+  });
+  return Object.assign(adapter, { mode: 'prism', fallbackReason: lastError });
+}

--- a/robopack-rocket/content/monaco-loader.js
+++ b/robopack-rocket/content/monaco-loader.js
@@ -1,0 +1,133 @@
+const CDN_BASE = 'https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min';
+let monacoLoaderPromise = null;
+
+function loadScriptOnce(url) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = true;
+    script.addEventListener('load', resolve, { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${url}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+async function ensureMonaco() {
+  if (window.monaco) {
+    return window.monaco;
+  }
+  if (!monacoLoaderPromise) {
+    monacoLoaderPromise = new Promise(async (resolve, reject) => {
+      try {
+        await loadScriptOnce(`${CDN_BASE}/vs/loader.js`);
+        if (!window.require) {
+          reject(new Error('Monaco AMD loader missing'));
+          return;
+        }
+        window.require.config({ paths: { vs: `${CDN_BASE}/vs` } });
+        window.MonacoEnvironment = {
+          getWorkerUrl: function (_moduleId, label) {
+            const workerPath = label === 'json' ? 'json.worker.js' : label === 'css' || label === 'scss' || label === 'less'
+              ? 'css.worker.js'
+              : label === 'html' || label === 'handlebars' || label === 'razor'
+                ? 'html.worker.js'
+                : label === 'typescript' || label === 'javascript'
+                  ? 'ts.worker.js'
+                  : 'editor.worker.js';
+            const proxy = `self.MonacoEnvironment = { baseUrl: '${CDN_BASE}/' }; importScripts('${CDN_BASE}/vs/base/worker/${workerPath}');`;
+            return URL.createObjectURL(new Blob([proxy], { type: 'text/javascript' }));
+          }
+        };
+        window.require(['vs/editor/editor.main'], () => {
+          resolve(window.monaco);
+        }, reject);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+  return monacoLoaderPromise;
+}
+
+export async function createMonacoAdapter(textarea, config) {
+  const monaco = await ensureMonaco();
+  const options = config.options || {};
+  const hostElement = config.hostElement;
+  const theme = config.theme || 'light';
+
+  hostElement.textContent = '';
+  const container = document.createElement('div');
+  container.className = 'rpwsh-editor-canvas';
+  hostElement.appendChild(container);
+
+  const model = monaco.editor.createModel(textarea.value, 'powershell');
+  model.updateOptions({
+    tabSize: Number(options.tabSize) || 4,
+    insertSpaces: true
+  });
+
+  const editor = monaco.editor.create(container, {
+    model,
+    automaticLayout: true,
+    minimap: { enabled: false },
+    fontSize: Number(options.fontSize) || 14,
+    tabSize: Number(options.tabSize) || 4,
+    insertSpaces: true,
+    detectIndentation: false,
+    wordWrap: options.wordWrap ? 'on' : 'off',
+    renderLineHighlight: 'all',
+    fixedOverflowWidgets: true,
+    scrollBeyondLastLine: false
+  });
+
+  monaco.editor.setModelLanguage(model, 'powershell');
+  setTheme(theme);
+
+  let applying = false;
+  const listeners = new Set();
+  const subscription = editor.onDidChangeModelContent(() => {
+    if (applying) return;
+    const value = editor.getValue();
+    listeners.forEach((cb) => {
+      try {
+        cb(value);
+      } catch (error) {
+        console.error('Listener error', error);
+      }
+    });
+  });
+
+  function setTheme(nextTheme) {
+    if (nextTheme === 'dark') {
+      monaco.editor.setTheme('vs-dark');
+    } else {
+      monaco.editor.setTheme('vs');
+    }
+  }
+
+  return {
+    api: {
+      getValue: () => editor.getValue(),
+      setValue: (value) => {
+        const safe = value ?? '';
+        if (editor.getValue() === safe) return;
+        applying = true;
+        editor.setValue(safe);
+        applying = false;
+      },
+      onChange: (cb) => {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      focus: () => editor.focus(),
+      setTheme: setTheme
+    },
+    dispose: () => {
+      subscription.dispose();
+      listeners.clear();
+      model.dispose();
+      editor.dispose();
+      container.remove();
+    }
+  };
+}

--- a/robopack-rocket/content/prism-loader.js
+++ b/robopack-rocket/content/prism-loader.js
@@ -1,0 +1,213 @@
+const PRISM_VERSION = '1.29.0';
+const PRISM_BASE = `https://cdn.jsdelivr.net/npm/prismjs@${PRISM_VERSION}`;
+let prismPromise = null;
+let loadedThemes = new Set();
+
+function loadScript(url) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = true;
+    script.addEventListener('load', resolve, { once: true });
+    script.addEventListener('error', () => reject(new Error(`Failed to load ${url}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+function loadCSS(url) {
+  return new Promise((resolve, reject) => {
+    try {
+      if ([...document.styleSheets].some((sheet) => sheet.href === url)) {
+        resolve();
+        return;
+      }
+    } catch (error) {
+      // Accessing sheet.href can fail because of CORS; ignore and proceed to inject.
+    }
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = url;
+    link.addEventListener('load', resolve, { once: true });
+    link.addEventListener('error', () => reject(new Error(`Failed to load ${url}`)), { once: true });
+    document.head.appendChild(link);
+  });
+}
+
+async function ensurePrism(theme) {
+  if (!prismPromise) {
+    prismPromise = new Promise(async (resolve, reject) => {
+      try {
+        await loadScript(`${PRISM_BASE}/components/prism-core.min.js`);
+        await loadScript(`${PRISM_BASE}/components/prism-clike.min.js`);
+        await loadScript(`${PRISM_BASE}/components/prism-powershell.min.js`);
+        await loadScript(`${PRISM_BASE}/plugins/line-numbers/prism-line-numbers.min.js`);
+        resolve(window.Prism);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+  const Prism = await prismPromise;
+  await ensureTheme(theme || 'light');
+  return Prism;
+}
+
+async function ensureTheme(theme) {
+  const key = theme === 'dark' ? 'prism-tomorrow' : 'prism';
+  if (loadedThemes.has(key)) return;
+  const cssUrl = theme === 'dark'
+    ? `${PRISM_BASE}/themes/prism-tomorrow.min.css`
+    : `${PRISM_BASE}/themes/prism.min.css`;
+  await loadCSS(cssUrl);
+  await loadCSS(`${PRISM_BASE}/plugins/line-numbers/prism-line-numbers.min.css`);
+  loadedThemes.add(key);
+}
+
+export async function createPrismAdapter(textarea, config) {
+  const hostElement = config.hostElement;
+  const options = config.options || {};
+  const theme = config.theme || 'light';
+  const fallbackReason = config.fallbackReason || null;
+  const Prism = await ensurePrism(theme);
+
+  hostElement.textContent = '';
+  const container = document.createElement('div');
+  container.className = 'rpwsh-prism-container rpwsh-editor-canvas';
+  hostElement.appendChild(container);
+
+  const highlight = document.createElement('pre');
+  highlight.className = 'language-powershell rpwsh-prism-highlight line-numbers';
+  const code = document.createElement('code');
+  code.className = 'language-powershell';
+  highlight.appendChild(code);
+
+  const editable = document.createElement('div');
+  editable.className = 'rpwsh-prism-editable';
+  editable.contentEditable = 'true';
+  editable.spellcheck = false;
+  editable.setAttribute('role', 'textbox');
+  editable.setAttribute('aria-label', 'PowerShell code editor');
+  editable.setAttribute('aria-multiline', 'true');
+  editable.style.fontSize = `${options.fontSize || 14}px`;
+  editable.style.tabSize = String(options.tabSize || 4);
+  editable.style.whiteSpace = options.wordWrap ? 'pre-wrap' : 'pre';
+  highlight.style.whiteSpace = editable.style.whiteSpace;
+  highlight.style.tabSize = editable.style.tabSize;
+
+  const updateHighlight = () => {
+    const value = getValue();
+    highlight.querySelectorAll('.line-numbers-rows').forEach((node) => node.remove());
+    code.textContent = value;
+    Prism.highlightElement(code);
+  };
+
+  const syncScroll = () => {
+    highlight.scrollTop = editable.scrollTop;
+    highlight.scrollLeft = editable.scrollLeft;
+  };
+
+  editable.addEventListener('scroll', syncScroll);
+
+  let applying = false;
+  const listeners = new Set();
+  const debouncedNotify = debounce(() => {
+    const value = getValue();
+    listeners.forEach((cb) => {
+      try {
+        cb(value);
+      } catch (error) {
+        console.error('Listener error', error);
+      }
+    });
+  }, 120);
+
+  const observer = new MutationObserver(() => {
+    if (applying) return;
+    updateHighlight();
+    debouncedNotify();
+  });
+  observer.observe(editable, { characterData: true, childList: true, subtree: true });
+
+  editable.addEventListener('input', () => {
+    if (applying) return;
+    updateHighlight();
+    debouncedNotify();
+  });
+
+  editable.addEventListener('keydown', (event) => {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      insertAtCursor(' '.repeat(options.tabSize || 2));
+    }
+  });
+
+  editable.addEventListener('paste', (event) => {
+    event.preventDefault();
+    const text = (event.clipboardData || window.clipboardData).getData('text');
+    insertAtCursor(text);
+  });
+
+  container.appendChild(highlight);
+  container.appendChild(editable);
+
+  setValue(textarea.value);
+  setTheme(theme);
+
+  function insertAtCursor(text) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    const textNode = document.createTextNode(text);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.setEndAfter(textNode);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    editable.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function getValue() {
+    return editable.textContent || '';
+  }
+
+  function setValue(value) {
+    applying = true;
+    editable.textContent = value ?? '';
+    applying = false;
+    updateHighlight();
+  }
+
+  function setTheme(nextTheme) {
+    ensureTheme(nextTheme).catch((error) => console.warn('Failed to load Prism theme', error));
+    container.dataset.theme = nextTheme;
+    editable.style.caretColor = nextTheme === 'dark' ? '#f8fafc' : '#0f172a';
+  }
+
+  return {
+    api: {
+      getValue,
+      setValue,
+      onChange: (cb) => {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      focus: () => editable.focus(),
+      setTheme
+    },
+    dispose: () => {
+      listeners.clear();
+      observer.disconnect();
+      container.remove();
+    },
+    fallbackReason
+  };
+}
+
+function debounce(fn, delay) {
+  let handle = null;
+  return function (...args) {
+    clearTimeout(handle);
+    handle = setTimeout(() => fn.apply(this, args), delay);
+  };
+}

--- a/robopack-rocket/lib/toast.js
+++ b/robopack-rocket/lib/toast.js
@@ -1,0 +1,47 @@
+(() => {
+  const ACTIVE_TOASTS = new Set();
+
+  function buildToast(message, options = {}) {
+    const toast = document.createElement('div');
+    toast.className = 'rpwsh-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+    if (options.theme) {
+      toast.dataset.theme = options.theme;
+    }
+    toast.textContent = message;
+    if (options.action) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = options.action.label;
+      btn.addEventListener('click', () => {
+        options.action.handler?.();
+        dismissToast(toast);
+      });
+      toast.appendChild(btn);
+    }
+    return toast;
+  }
+
+  function dismissToast(toast) {
+    if (!toast) return;
+    ACTIVE_TOASTS.delete(toast);
+    toast.remove();
+  }
+
+  function showToast(message, options = {}) {
+    const toast = buildToast(message, options);
+    ACTIVE_TOASTS.add(toast);
+    document.body.appendChild(toast);
+    const lifetime = options.duration ?? 5000;
+    if (lifetime > 0) {
+      setTimeout(() => dismissToast(toast), lifetime);
+    }
+    return () => dismissToast(toast);
+  }
+
+  window.RoboToast = {
+    show: showToast,
+    dismiss: dismissToast
+  };
+})();

--- a/robopack-rocket/manifest.json
+++ b/robopack-rocket/manifest.json
@@ -1,0 +1,44 @@
+{
+  "manifest_version": 3,
+  "name": "Robopack Rocket",
+  "description": "Launch a Monaco/Prism editor for RoboPack PowerShell fields with syncing, resizing, and customization.",
+  "version": "1.0.0",
+  "permissions": [
+    "storage",
+    "scripting"
+  ],
+  "host_permissions": [
+    "https://robopack.com/*",
+    "https://*.robopack.com/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "https://robopack.com/*",
+        "https://*.robopack.com/*"
+      ],
+      "js": ["content/content.js"],
+      "css": ["content/editor.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "content/editor.js",
+        "content/monaco-loader.js",
+        "content/prism-loader.js",
+        "content/editor.css",
+        "lib/toast.js"
+      ],
+      "matches": [
+        "https://robopack.com/*",
+        "https://*.robopack.com/*"
+      ]
+    }
+  ]
+}

--- a/robopack-rocket/options/options.css
+++ b/robopack-rocket/options/options.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  --accent: #1f6feb;
+  --bg: #0f172a;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #0b1220;
+  color: #e2e8f0;
+}
+
+.options {
+  max-width: 720px;
+  margin: 3rem auto;
+  padding: 2rem 2.5rem 3rem;
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 16px;
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.7);
+  backdrop-filter: blur(12px);
+}
+
+.options header h1 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+section {
+  margin-top: 2rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+  padding-top: 1.5rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+  font-weight: 500;
+}
+
+label input[type="text"],
+label input[type="number"],
+label select {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font-size: 1rem;
+}
+
+label small {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.actions {
+  margin-top: 2.5rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #1f6feb, #2563eb);
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(37, 99, 235, 0.35);
+}
+
+button:not(.primary) {
+  background: rgba(148, 163, 184, 0.25);
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(250, 204, 21, 0.75);
+  outline-offset: 2px;
+}
+
+#test-status {
+  min-height: 1.5rem;
+}
+
+.flash {
+  position: fixed;
+  inset-inline-end: 24px;
+  inset-block-start: 24px;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.95);
+  color: #fff;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.flash[data-variant="error"] {
+  background: rgba(239, 68, 68, 0.95);
+}
+
+.flash[data-variant="info"] {
+  background: rgba(14, 116, 144, 0.95);
+}
+
+.flash.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .options {
+    margin: 1rem;
+    padding: 1.5rem;
+  }
+}

--- a/robopack-rocket/options/options.html
+++ b/robopack-rocket/options/options.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Robopack Rocket Options</title>
+  <link rel="stylesheet" href="options.css" />
+</head>
+<body>
+  <main class="options">
+    <header>
+      <h1>Robopack Rocket</h1>
+      <p>Configure how the enhanced PowerShell editor behaves on RoboPack.</p>
+    </header>
+    <form id="options-form">
+      <section>
+        <h2>Textarea Detection</h2>
+        <label>
+          <span>Custom textarea selectors (comma separated)</span>
+          <input type="text" id="selectors" name="selectors" placeholder="textarea[id*=powershell], textarea.custom" />
+          <small>Leave blank to use the built-in heuristic for large script inputs.</small>
+        </label>
+        <button type="button" id="test-selectors">Test selectors on current tab</button>
+        <p class="test-status" id="test-status" role="status" aria-live="polite"></p>
+      </section>
+
+      <section>
+        <h2>Editor Preferences</h2>
+        <label>
+          <span>Preferred highlighter</span>
+          <select id="preferredHighlighter" name="preferredHighlighter">
+            <option value="auto">Auto (try Monaco, fallback to Prism)</option>
+            <option value="monaco">Monaco</option>
+            <option value="prism">Prism</option>
+          </select>
+        </label>
+        <label>
+          <span>Font size (px)</span>
+          <input type="number" id="fontSize" name="fontSize" min="10" max="32" step="1" />
+        </label>
+        <label>
+          <span>Tab size (spaces)</span>
+          <input type="number" id="tabSize" name="tabSize" min="2" max="8" step="1" />
+        </label>
+        <label class="checkbox">
+          <input type="checkbox" id="wordWrap" name="wordWrap" />
+          <span>Enable word wrap</span>
+        </label>
+        <label>
+          <span>Theme override</span>
+          <select id="theme" name="theme">
+            <option value="auto">Auto (follow page / system)</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </section>
+
+      <footer class="actions">
+        <button type="submit" class="primary">Save</button>
+        <button type="button" id="reset">Reset to defaults</button>
+      </footer>
+    </form>
+  </main>
+
+  <template id="toast-template">
+    <div class="flash" role="status" aria-live="polite"></div>
+  </template>
+
+  <script src="options.js" type="module"></script>
+</body>
+</html>

--- a/robopack-rocket/options/options.js
+++ b/robopack-rocket/options/options.js
@@ -1,0 +1,122 @@
+const browserAPI = window.browser ?? window.chrome;
+const SETTINGS_KEY = 'robopackRocketSettings';
+const DEFAULT_SETTINGS = {
+  selectors: '',
+  preferredHighlighter: 'auto',
+  fontSize: 14,
+  tabSize: 4,
+  wordWrap: false,
+  theme: 'auto'
+};
+
+const form = document.getElementById('options-form');
+const selectorsInput = document.getElementById('selectors');
+const preferredInput = document.getElementById('preferredHighlighter');
+const fontSizeInput = document.getElementById('fontSize');
+const tabSizeInput = document.getElementById('tabSize');
+const wordWrapInput = document.getElementById('wordWrap');
+const themeInput = document.getElementById('theme');
+const testButton = document.getElementById('test-selectors');
+const testStatus = document.getElementById('test-status');
+const resetButton = document.getElementById('reset');
+
+init();
+
+async function init() {
+  const stored = await browserAPI.storage.local.get(SETTINGS_KEY);
+  const settings = Object.assign({}, DEFAULT_SETTINGS, stored?.[SETTINGS_KEY] ?? {});
+  applySettingsToForm(settings);
+}
+
+function applySettingsToForm(settings) {
+  selectorsInput.value = settings.selectors ?? '';
+  preferredInput.value = settings.preferredHighlighter ?? 'auto';
+  fontSizeInput.value = settings.fontSize ?? 14;
+  tabSizeInput.value = settings.tabSize ?? 4;
+  wordWrapInput.checked = Boolean(settings.wordWrap);
+  themeInput.value = settings.theme ?? 'auto';
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const data = collectFormValues();
+  if (!data) {
+    return;
+  }
+  await browserAPI.storage.local.set({ [SETTINGS_KEY]: data });
+  flash('Saved successfully.', 'success');
+});
+
+resetButton.addEventListener('click', async () => {
+  applySettingsToForm(DEFAULT_SETTINGS);
+  await browserAPI.storage.local.set({ [SETTINGS_KEY]: DEFAULT_SETTINGS });
+  flash('Settings reset to defaults.', 'info');
+});
+
+testButton.addEventListener('click', async () => {
+  const payload = collectFormValues(false);
+  if (!payload) {
+    return;
+  }
+  try {
+    const response = await browserAPI.runtime.sendMessage({
+      type: 'robopack-rocket-test-selectors',
+      settings: payload
+    });
+    if (response && typeof response.count === 'number') {
+      testStatus.textContent = `Matched ${response.count} textarea${response.count === 1 ? '' : 's'} on the current page.`;
+    } else {
+      testStatus.textContent = 'No response from content script. Ensure a RoboPack tab is open.';
+    }
+  } catch (error) {
+    console.error('Test selector failed', error);
+    testStatus.textContent = 'Could not reach the current tab. Is a RoboPack page open?';
+  }
+});
+
+function collectFormValues(showErrors = true) {
+  const selectors = selectorsInput.value.trim();
+  const preferredHighlighter = preferredInput.value;
+  const fontSize = Number(fontSizeInput.value);
+  const tabSize = Number(tabSizeInput.value);
+  const wordWrap = wordWrapInput.checked;
+  const theme = themeInput.value;
+
+  if (!Number.isFinite(fontSize) || fontSize < 10 || fontSize > 32) {
+    if (showErrors) {
+      flash('Font size must be between 10 and 32.', 'error');
+    }
+    return null;
+  }
+
+  if (!Number.isFinite(tabSize) || tabSize < 2 || tabSize > 8) {
+    if (showErrors) {
+      flash('Tab size must be between 2 and 8.', 'error');
+    }
+    return null;
+  }
+
+  return {
+    selectors,
+    preferredHighlighter,
+    fontSize,
+    tabSize,
+    wordWrap,
+    theme
+  };
+}
+
+function flash(message, variant = 'info') {
+  const template = document.getElementById('toast-template');
+  const el = template.content.firstElementChild.cloneNode(true);
+  el.textContent = message;
+  el.dataset.variant = variant;
+  document.body.appendChild(el);
+  requestAnimationFrame(() => {
+    el.classList.add('show');
+  });
+  setTimeout(() => {
+    el.classList.remove('show');
+    setTimeout(() => el.remove(), 250);
+  }, 2400);
+}


### PR DESCRIPTION
## Summary
- remove packaged icon assets from the Robopack Rocket extension bundle
- update the manifest to stop referencing the deleted icons

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68d52487f93483249a9b8167b85c5543