### PR TITLE
Support container selectors for textarea detection

### DIFF
--- a/robopack-rocket/content/content.js
+++ b/robopack-rocket/content/content.js
@@ -69,7 +69,11 @@
         document.querySelectorAll(sel).forEach((node) => {
           if (node instanceof HTMLTextAreaElement) {
             candidates.add(node);
+            return;
           }
+          node.querySelectorAll?.('textarea').forEach((textarea) => {
+            candidates.add(textarea);
+          });
         });
       } catch (err) {
         console.warn('[Robopack Rocket] Invalid selector', sel, err);

--- a/robopack-rocket/options/options.html
+++ b/robopack-rocket/options/options.html
@@ -16,8 +16,8 @@
         <h2>Textarea Detection</h2>
         <label>
           <span>Custom textarea selectors (comma separated)</span>
-          <input type="text" id="selectors" name="selectors" placeholder="textarea[id*=powershell], textarea.custom" />
-          <small>Leave blank to use the built-in heuristic for large script inputs.</small>
+          <input type="text" id="selectors" name="selectors" placeholder="textarea[id*=powershell], .v-window__container textarea" />
+          <small>Selectors may target a textarea directly or a container that holds one. Leave blank to use the built-in heuristic for large script inputs.</small>
         </label>
         <button type="button" id="test-selectors">Test selectors on current tab</button>
         <p class="test-status" id="test-status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- allow custom selectors to resolve descendant textareas within matched containers
- document container selector support in the options UI placeholder and help text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d62eee6c90832499cde9087c41b332