### PR TITLE
Fix selector test messaging for RoboPack tabs

### DIFF
--- a/robopack-rocket/manifest.json
+++ b/robopack-rocket/manifest.json
@@ -5,7 +5,8 @@
   "version": "1.0.0",
   "permissions": [
     "storage",
-    "scripting"
+    "scripting",
+    "tabs"
   ],
   "host_permissions": [
     "https://robopack.com/*",

--- a/robopack-rocket/options/options.js
+++ b/robopack-rocket/options/options.js
@@ -19,6 +19,7 @@ const themeInput = document.getElementById('theme');
 const testButton = document.getElementById('test-selectors');
 const testStatus = document.getElementById('test-status');
 const resetButton = document.getElementById('reset');
+const ROBO_PACK_URLS = ['https://robopack.com/*', 'https://*.robopack.com/*'];
 
 init();
 
@@ -58,21 +59,88 @@ testButton.addEventListener('click', async () => {
   if (!payload) {
     return;
   }
+
+  testStatus.textContent = 'Looking for an open RoboPack tab...';
+
   try {
-    const response = await browserAPI.runtime.sendMessage({
+    const tabs = await queryRoboPackTabs();
+    if (!tabs.length) {
+      testStatus.textContent = 'No RoboPack tab detected. Open one and try again.';
+      return;
+    }
+
+    const targetTab = tabs.find((tab) => tab.active && tab.id != null) ?? tabs.find((tab) => tab.id != null);
+    if (!targetTab?.id) {
+      testStatus.textContent = 'Found a RoboPack tab but could not contact it. Try reloading the page.';
+      return;
+    }
+
+    const response = await sendMessageToTab(targetTab.id, {
       type: 'robopack-rocket-test-selectors',
       settings: payload
     });
+
     if (response && typeof response.count === 'number') {
-      testStatus.textContent = `Matched ${response.count} textarea${response.count === 1 ? '' : 's'} on the current page.`;
+      const label = targetTab.title ? `“${targetTab.title.trim()}”` : 'the RoboPack tab';
+      testStatus.textContent = `Matched ${response.count} textarea${response.count === 1 ? '' : 's'} on ${label}.`;
     } else {
-      testStatus.textContent = 'No response from content script. Ensure a RoboPack tab is open.';
+      testStatus.textContent = 'The RoboPack tab did not respond. Reload it and try again.';
     }
   } catch (error) {
     console.error('Test selector failed', error);
-    testStatus.textContent = 'Could not reach the current tab. Is a RoboPack page open?';
+    const message = error?.message?.includes('Receiving end does not exist')
+      ? 'The RoboPack tab is not ready yet. Reload it and try again.'
+      : 'Could not reach a RoboPack tab. Ensure one is open and try again.';
+    testStatus.textContent = message;
   }
 });
+
+function queryRoboPackTabs() {
+  if (!browserAPI.tabs?.query) {
+    return Promise.resolve([]);
+  }
+
+  const queryInfo = { url: ROBO_PACK_URLS };
+
+  if (browserAPI.tabs.query.length > 1) {
+    return new Promise((resolve, reject) => {
+      browserAPI.tabs.query(queryInfo, (tabs) => {
+        const lastError = browserAPI.runtime?.lastError;
+        if (lastError) {
+          reject(new Error(lastError.message));
+          return;
+        }
+        resolve(tabs ?? []);
+      });
+    });
+  }
+
+  return browserAPI.tabs.query(queryInfo).catch((error) => {
+    console.error('Failed to query RoboPack tabs', error);
+    throw error;
+  });
+}
+
+function sendMessageToTab(tabId, message) {
+  if (!browserAPI.tabs?.sendMessage) {
+    return browserAPI.runtime.sendMessage(message);
+  }
+
+  if (browserAPI.tabs.sendMessage.length > 2) {
+    return new Promise((resolve, reject) => {
+      browserAPI.tabs.sendMessage(tabId, message, (response) => {
+        const lastError = browserAPI.runtime?.lastError;
+        if (lastError) {
+          reject(new Error(lastError.message));
+          return;
+        }
+        resolve(response);
+      });
+    });
+  }
+
+  return browserAPI.tabs.sendMessage(tabId, message);
+}
 
 function collectFormValues(showErrors = true) {
   const selectors = selectorsInput.value.trim();


### PR DESCRIPTION
## Summary
- query RoboPack tabs before running the selector test from the options page
- add messaging fallbacks so the options UI reports clearer status updates
- request the tabs permission to allow the options page to reach RoboPack tabs

## Testing
- not run (extension change only)


------
https://chatgpt.com/codex/tasks/task_e_68d6340aa3b083248c08b25ab688f769