### PR TITLE
Remove toolbar icon assets

### DIFF
--- a/robopack-rocket/README.md
+++ b/robopack-rocket/README.md
@@ -1,6 +1,6 @@
 # Robopack Rocket
 
-Robopack Rocket is a Firefox Manifest V3 extension that upgrades the custom PowerShell settings editor on [robopack.com](https://robopack.com) with a fully featured coding experience. It transparently keeps the original `<textarea>` as the source of truth so site forms continue to work while you enjoy syntax highlighting, code-editor ergonomics, and persistent sizing.
+Robopack Rocket is a cross-browser Manifest V3 extension (Firefox, Chrome, and Microsoft Edge) that upgrades the custom PowerShell settings editor on [robopack.com](https://robopack.com) with a fully featured coding experience. It transparently keeps the original `<textarea>` as the source of truth so site forms continue to work while you enjoy syntax highlighting, code-editor ergonomics, and persistent sizing.
 
 ## Features
 
@@ -8,16 +8,35 @@ Robopack Rocket is a Firefox Manifest V3 extension that upgrades the custom Powe
 - **Two-way syncing** – The original `<textarea>` stays in place (hidden when the editor is active) and stays in sync with every keystroke so native site behaviour keeps working.
 - **Resizable workspace** – Drag the corner grip or use the keyboard to adjust editor height. The chosen size is remembered per RoboPack path.
 - **Toggle friendly** – Switch between the stock textarea and the enhanced editor at any time without losing content.
+- **Toolbar shortcut** – Pin the browser action to jump to options instantly in Chrome, Edge, or Firefox.
 - **Options page** – Customise selectors, fonts, tab stops, wrapping, theme override, and your preferred highlighter (Monaco, Prism, or automatic).
 - **Per-site persistence** – Editor dimensions and preferences are stored per origin + path so different RoboPack sections can have different layouts.
 - **Accessible toasts & controls** – Keyboard focus, labelled buttons, and polite toasts keep the experience inclusive.
 
 ## Installation
 
+### Firefox (temporary install for development)
+
 1. Clone or download this repository.
 2. Open Firefox and visit `about:debugging#/runtime/this-firefox`.
 3. Click **Load Temporary Add-on…** and choose the `manifest.json` file inside the `robopack-rocket` directory.
 4. Open a RoboPack page containing a large PowerShell textarea (e.g. custom settings). The extension enhances it automatically.
+
+### Chrome (unpacked load)
+
+1. Clone or download this repository.
+2. Open Chrome and navigate to `chrome://extensions`.
+3. Enable **Developer mode** (top-right toggle).
+4. Click **Load unpacked** and select the `robopack-rocket` directory.
+5. Pin the **Robopack Rocket** icon from the extensions tray if you want quick access to the options popup.
+
+### Microsoft Edge (unpacked load)
+
+1. Clone or download this repository.
+2. Open Edge and navigate to `edge://extensions`.
+3. Turn on **Developer mode**.
+4. Click **Load unpacked** and choose the `robopack-rocket` directory.
+5. Pin the **Robopack Rocket** icon from the toolbar if you'd like quick access to the options popup.
 
 ## Usage
 

--- a/robopack-rocket/manifest.json
+++ b/robopack-rocket/manifest.json
@@ -23,6 +23,10 @@
       "run_at": "document_idle"
     }
   ],
+  "action": {
+    "default_title": "Robopack Rocket",
+    "default_popup": "options/action-popup.html"
+  },
   "options_ui": {
     "page": "options/options.html",
     "open_in_tab": true

--- a/robopack-rocket/options/action-popup.html
+++ b/robopack-rocket/options/action-popup.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Robopack Rocket</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+      background: #0b1026;
+      color: #e2e8f0;
+    }
+
+    body {
+      margin: 0;
+      min-width: 240px;
+      padding: 16px;
+      background: radial-gradient(circle at top, rgba(59, 130, 246, 0.25), transparent 65%), #0b1026;
+    }
+
+    h1 {
+      font-size: 18px;
+      margin: 0 0 4px;
+      font-weight: 600;
+    }
+
+    p {
+      margin: 0 0 12px;
+      font-size: 13px;
+      line-height: 1.4;
+    }
+
+    button {
+      appearance: none;
+      border: none;
+      border-radius: 999px;
+      background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      color: #fff;
+      font-weight: 600;
+      padding: 8px 14px;
+      cursor: pointer;
+      font-size: 13px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      box-shadow: 0 6px 20px rgba(15, 23, 42, 0.35);
+    }
+
+    button:hover,
+    button:focus-visible {
+      outline: none;
+      background: linear-gradient(135deg, #2563eb, #7c3aed);
+    }
+
+    .links {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Robopack Rocket</h1>
+  <p>Open the options page to customise selectors, fonts, and highlighting for RoboPack.</p>
+  <div class="links">
+    <button id="open-options" type="button">Open options</button>
+  </div>
+  <script type="module" src="action-popup.js"></script>
+</body>
+</html>

--- a/robopack-rocket/options/action-popup.js
+++ b/robopack-rocket/options/action-popup.js
@@ -1,0 +1,12 @@
+const browserAPI = window.browser ?? window.chrome;
+
+const openOptionsButton = document.getElementById('open-options');
+
+openOptionsButton?.addEventListener('click', () => {
+  if (browserAPI?.runtime?.openOptionsPage) {
+    browserAPI.runtime.openOptionsPage();
+  } else if (browserAPI?.tabs?.create) {
+    browserAPI.tabs.create({ url: browserAPI.runtime.getURL('options/options.html') });
+  }
+  window.close();
+});


### PR DESCRIPTION
## Summary
- delete the bundled PNG toolbar icons that were added for the action popup
- update the manifest to stop referencing the removed binary assets while keeping the popup entry point

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d671d7430c8324af68b4b66a6ef587